### PR TITLE
Refactor plugins and main module

### DIFF
--- a/comeback/main.py
+++ b/comeback/main.py
@@ -26,11 +26,11 @@ def get_probable_project_name():
 
 
 def call_plugin(module, plugin_name, **plugin_params):
-    is_startable, err = module.check(**plugin_params)
+    is_startable, err = module.check_plugin(**plugin_params)
     if not is_startable:
         click.echo(f"Couldn't use plugin {plugin_name}: {err}")
         exit()
-    module.run(**plugin_params)
+    module.run_plugin(**plugin_params)
 
 
 def is_plugin_exists(plugin_name):

--- a/comeback/main.py
+++ b/comeback/main.py
@@ -53,8 +53,8 @@ def run_config(config):
         if not is_plugin_exists(plugin_name):
             exit()
 
-        verbose_echo('Starting {plugin_name}...')
-        verbose_echo('\tParams {plugin_params}...')
+        verbose_echo(f'Starting {plugin_name}...')
+        verbose_echo(f'\tParams {plugin_params}...')
         
         load_plugin(plugin_name, plugin_params)
 
@@ -70,7 +70,7 @@ def read_config_file(config_path):
 
 
 def load_config():
-    verbose_echo('Loading configuration file form: {cwd}')
+    verbose_echo(f'Loading configuration file form: {get_cwd()}')
     config_path = get_cwd() / '.comeback'
     config = read_config_file(config_path)
 

--- a/comeback/main.py
+++ b/comeback/main.py
@@ -63,8 +63,8 @@ def read_config_file(config_path):
     try:
         with open(config_path, 'r') as fd:
             return yaml.load(fd)
-    except IOError:
-        print(f'Could not read file: {config_path}')
+    except IOError as e:
+        click.echo(f'Could not read file {config_path} because {e}')
     except yaml.YAMLError as exc:
         click.echo(exc)
 
@@ -96,6 +96,7 @@ def cli(init, verbose):
 
     if init:
         verbose_echo('Creating a blank .comeback configuration file.')
+        get_cwd().joinpath('.comeback').touch()
         return
 
     main()

--- a/comeback/plugins/__init__.py
+++ b/comeback/plugins/__init__.py
@@ -1,0 +1,6 @@
+import pathlib
+import pkgutil
+
+
+dirname = pathlib.Path(__file__).parent
+__all__ = [module for _, module, _ in pkgutil.iter_modules([dirname])]

--- a/comeback/plugins/chrome/main.py
+++ b/comeback/plugins/chrome/main.py
@@ -15,7 +15,7 @@ def open_url_with_browser(browser_name, url):
 
 
 
-def check(url=None):
+def check_plugin(url=None):
     """Test if we can use this plugin"""
     if url is None:
         return False, 'url parameter is not set.'
@@ -23,7 +23,7 @@ def check(url=None):
     return True, None
 
 
-def run(url):
+def run_plugin(url):
     browser_names = ['google-chrome', 'chrome']
     success = False
 

--- a/comeback/plugins/chrome/main.py
+++ b/comeback/plugins/chrome/main.py
@@ -1,32 +1,36 @@
 import os
 import subprocess
+import webbrowser
+
 from comeback import utils
 
 
-def cb_test(options):
-    """
-        Test if we can use this plugin
-    """
-    if 'url' not in options:
-        return False, 'URL parameter is not set.'
+def open_url_with_browser(browser_name, url):
+    try:
+        browser = webbrowser.get(using=browser_name)
+        browser.open_new_tab(url)
+        return True
+    except webbrowser.Error:
+        return False
 
-    if not utils.module_exists('webbrowser'):
-        return False, 'webbrowser module doesn\'t exist!'
+
+
+def check(url=None):
+    """Test if we can use this plugin"""
+    if url is None:
+        return False, 'url parameter is not set.'
 
     return True, None
 
 
-def cb_start(options):
-    import webbrowser
-    new = 2  # open in a new tab
-    try:
-        webbrowser.get(using='google-chrome').open(options['url'], new=new)
-    except webbrowser.Error:
-        pass
+def run(url):
+    browser_names = ['google-chrome', 'chrome']
+    success = False
 
-    # Try to open again, and if it doesn't work open the default
-    try:
-        webbrowser.get(using='chrome').open(options['url'], new=new)
-    except webbrowser.Error:
-        webbrowser.open(options['url'], new=new)
+    while browser_names and not success:
+        browser_name = browser_names.pop()
+        success = open_url_with_browser(browser_name, url)
+    
+    if not success:
+        webbrowser.open_new_tab(url)
 

--- a/comeback/plugins/vscode/main.py
+++ b/comeback/plugins/vscode/main.py
@@ -1,21 +1,21 @@
 import os
+import pathlib
 import subprocess
+
 from comeback import utils
 
 
-def cb_test(options):
-    """
-        Test if we can use this plugin
-    """
-    if 'cwd' not in options:
-        return False, 'URL parameter is not set.'
+def check(cwd=None):
+    """Test if we can use this plugin"""
+    if 'cwd' is None:
+        return False, 'cwd parameter is not set.'
 
-    if not utils.binary_exists("code"):
+    if not utils.binary_exists('code'):
         return False, 'vscode is not installed.'
 
     return True, None
 
 
-def cb_start(options):
-    cwd = os.path.expanduser(options['cwd'])
-    subprocess.call('code {cmd}'.format(cmd=cwd), shell=True)
+def run(cwd):
+    directory = pathlib.Path(cwd).expanduser()
+    subprocess.call(f'code {directory}', shell=True)

--- a/comeback/plugins/vscode/main.py
+++ b/comeback/plugins/vscode/main.py
@@ -5,7 +5,7 @@ import subprocess
 from comeback import utils
 
 
-def check(cwd=None):
+def check_plugin(cwd=None):
     """Test if we can use this plugin"""
     if 'cwd' is None:
         return False, 'cwd parameter is not set.'
@@ -16,6 +16,6 @@ def check(cwd=None):
     return True, None
 
 
-def run(cwd):
+def run_plugin(cwd):
     directory = pathlib.Path(cwd).expanduser()
     subprocess.call(f'code {directory}', shell=True)

--- a/comeback/utils.py
+++ b/comeback/utils.py
@@ -1,26 +1,27 @@
-from sys import platform as _platform
-import subprocess
 import importlib
+import platform
+from shutil import which
+import subprocess
 
 
 def get_platform():
-    if _platform.startswith("linux"):
-        return "linux"
-    elif _platform == "darwin":
-        return "mac"
-    elif _platform.startswith("win"):
-        return "windows"
-    return "other"
+    platforms = {
+        'Linux': 'linux',
+        'Windows': 'windows',
+        'Darwin': 'mac',
+    }
+    
+    return platforms.get(platform.system(), 'other')
 
 
-def open(cmd):
-    subprocess.Popen(cmd, shell=False, stdin=None, stdout=None, stderr=None, close_fds=True)
+def run(cmd):
+    subprocess.run(cmd)
+
 
 def binary_exists(bin_name):
-    from shutil import which
     return which(bin_name) is not None
 
 
-def module_exists(module_name):
+def is_module_exists(module_name):
     spec = importlib.util.find_spec(module_name)
     return spec is not None


### PR DESCRIPTION
* Sort imports
* Use `pathlib`
* Move the package listing to `package.__all__`
* Use absolute rather than relative imports
* Refactor functions structure
* Use dictionary unpacking on plugin parameters
* Catch `IOError` when trying to read config
* Use fstrings instead of `str.format(dict)`
* Format docstrings according to PEP 257
* Make all the code use `'` instead of `"`
* Use `platform` library instead of `_platform`