### PR TITLE
Add ability to run specific plugin

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -30,14 +30,10 @@
         },
         "pyyaml": {
             "hashes": [
-                "sha256:254bf6fda2b7c651837acb2c718e213df29d531eebf00edb54743d10bcb694eb",
-                "sha256:3108529b78577327d15eec243f0ff348a0640b0c3478d67ad7f5648f93bac3e2",
-                "sha256:3c17fb92c8ba2f525e4b5f7941d850e7a48c3a59b32d331e2502a3cdc6648e76",
-                "sha256:8d6d96001aa7f0a6a4a95e8143225b5d06e41b1131044913fecb8f85a125714b",
-                "sha256:c8a88edd93ee29ede719080b2be6cb2333dfee1dccba213b422a9c8e97f2967b"
+                "sha256:0b83c5697aed17a27efbb631a6a3846501375c6e55112a665b210f223fa69629"
             ],
             "index": "pypi",
-            "version": "==4.2b4"
+            "version": "==5.1b3"
         }
     },
     "develop": {}

--- a/comeback/main.py
+++ b/comeback/main.py
@@ -22,6 +22,18 @@ def get_probable_project_name():
     return get_cwd().name
 
 
+def parse_args(args_string):
+    if not args_string:
+        return {}
+
+    ret_args = {}
+    for arg in args_string.split(","):
+        key_value = arg.split("=")
+        ret_args[key_value[0]] = key_value[1]
+
+    return ret_args
+
+
 def call_plugin(module, plugin_name, **plugin_params):
     try:
         success, err = module.run_plugin(**plugin_params)
@@ -99,7 +111,7 @@ def main():
     load_config()
 
 
-@click.command()
+@click.group()
 @click.option('-i', '--init', default=False, help='Generate a blank \
     .comeback configuration file.')
 @click.option('-v', '--verbose', is_flag=True, help='Show more output.')
@@ -113,3 +125,13 @@ def cli(init, verbose):
         return
 
     main()
+
+
+@cli.command(context_settings=dict(
+    ignore_unknown_options=True,
+))
+@click.argument('plugin', required=False)
+@click.argument('plugin_params', required=False)
+def run(plugin, plugin_params):
+    verbose_echo("Running specific plugin.")
+    load_plugin(plugin, parse_args(plugin_params))

--- a/comeback/main.py
+++ b/comeback/main.py
@@ -127,9 +127,7 @@ def cli(init, verbose):
     main()
 
 
-@cli.command(context_settings=dict(
-    ignore_unknown_options=True,
-))
+@cli.command()
 @click.argument('plugin', required=False)
 @click.argument('plugin_params', required=False)
 def run(plugin, plugin_params):

--- a/comeback/main.py
+++ b/comeback/main.py
@@ -111,13 +111,18 @@ def main():
     load_config()
 
 
-@click.group()
+@click.group(invoke_without_command=True)
+@click.pass_context
 @click.option('-i', '--init', default=False, help='Generate a blank \
     .comeback configuration file.')
 @click.option('-v', '--verbose', is_flag=True, help='Show more output.')
-def cli(init, verbose):
+def cli(ctx, init, verbose):
     global IS_VERBOSE
     IS_VERBOSE = verbose
+
+    if ctx.invoked_subcommand is not None:
+        verbose_echo('Invoking subcommand: %s' % ctx.invoked_subcommand)
+        return
 
     if init:
         verbose_echo('Creating a blank .comeback configuration file.')
@@ -128,8 +133,9 @@ def cli(init, verbose):
 
 
 @cli.command()
-@click.argument('plugin', required=False)
+@click.argument('plugin', required=True)
 @click.argument('plugin_params', required=False)
 def run(plugin, plugin_params):
+    print(plugin, plugin_params)
     verbose_echo("Running specific plugin.")
     load_plugin(plugin, parse_args(plugin_params))

--- a/comeback/main.py
+++ b/comeback/main.py
@@ -136,6 +136,5 @@ def cli(ctx, init, verbose):
 @click.argument('plugin', required=True)
 @click.argument('plugin_params', required=False)
 def run(plugin, plugin_params):
-    print(plugin, plugin_params)
-    verbose_echo("Running specific plugin.")
+    verbose_echo(f'Running plugins: {plugin} with args: {plugin_params}')
     load_plugin(plugin, parse_args(plugin_params))

--- a/setup.py
+++ b/setup.py
@@ -12,12 +12,12 @@ setup(
     license="MIT",
     install_requires=[
         'click',
-        'pyyaml'
+        'pyyaml',
     ],
     entry_points={
         'console_scripts': ['comeback=comeback.main:cli'],
     },
-    download_url='https://github.com/agamm/comeback/archive/v0.0.1-alpha.tar.gz',
+    download_url='https://github.com/agamm/comeback/archive/v0.0.2-alpha.tar.gz',
     classifiers=[
         'Development Status :: 3 - Alpha',
         # "3 - Alpha", "4 - Beta" or "5 - Production/Stable"


### PR DESCRIPTION
Added the ability to run a specific plugin instead from the .comeback recipe.
Example: `comeback -v run vscode cwd=.`
Will be verbose, run the `vscode` plugin with the parameters: `cwd=.` 

Also update pipenv and pip.

fixes https://github.com/agamm/comeback/issues/18