### PR TITLE
Fix windows pycharm add global paths fixes

### DIFF
--- a/comeback/main.py
+++ b/comeback/main.py
@@ -11,7 +11,6 @@ from comeback import config
 from comeback import paths
 from comeback import plugins
 
-
 exit = sys.exit
 
 IS_VERBOSE = False
@@ -103,8 +102,13 @@ def read_config_file(config_path: pathlib.Path) -> Optional[Dict[str, Any]]:
 def get_config_path() -> pathlib.Path:
     cwd_path = paths.CURRENT_DIR / '.comeback'
     if cwd_path.exists():
+        config.add_comeback_path(cwd_path)
         return cwd_path
-    return config.get_last_comeback()
+
+    last_comeback_used = config.get_last_comeback()
+    verbose_echo("No .comeback file found in the current directory, " +
+                 "starting last session found ({}).".format(last_comeback_used))
+    return last_comeback_used
 
 
 def load_config() -> None:
@@ -113,6 +117,9 @@ def load_config() -> None:
     config = read_config_file(config_path)
 
     if config is None:
+        verbose_echo(
+            'Error: no .comeback file found in the current directory nor in ' +
+            'previous sessions.')
         return None
 
     run_config(config)

--- a/comeback/main.py
+++ b/comeback/main.py
@@ -106,8 +106,8 @@ def get_config_path() -> pathlib.Path:
         return cwd_path
 
     last_comeback_used = config.get_last_comeback()
-    verbose_echo("No .comeback file found in the current directory, " +
-                 "starting last session found ({}).".format(last_comeback_used))
+    verbose_echo('No .comeback file found in the current directory, ' +
+                 f'starting last session found ({last_comeback_used})')
     return last_comeback_used
 
 

--- a/comeback/plugins/pycharm/main.py
+++ b/comeback/plugins/pycharm/main.py
@@ -41,9 +41,9 @@ def run_windows(cwd: str) -> utils.RUN_STATUS:
     if not pyc32 and pyc64:
         return False, 'pycharm\'s exe files are not found.'
     elif pyc64:
-        utils.run([str(pycharm_exe64), str(cwd)], use_shell=False, detach = False)
+        utils.run([str(pycharm_exe64), str(cwd)], use_shell=False, detach=False)
     else:
-        utils.run([str(pycharm_exe64), str(cwd)], use_shell=False, detach = False)
+        utils.run([str(pycharm_exe64), str(cwd)], use_shell=False, detach=False)
 
     return True, 'Found pycharm'
 

--- a/comeback/plugins/pycharm/main.py
+++ b/comeback/plugins/pycharm/main.py
@@ -41,9 +41,9 @@ def run_windows(cwd: str) -> utils.RUN_STATUS:
     if not pyc32 and pyc64:
         return False, 'pycharm\'s exe files are not found.'
     elif pyc64:
-        utils.run(f'{pycharm_exe64} {cwd}')
+        utils.run([str(pycharm_exe64), str(cwd)], use_shell=False, detach = False)
     else:
-        utils.run(f'{pycharm_exe64} {cwd}')
+        utils.run([str(pycharm_exe64), str(cwd)], use_shell=False, detach = False)
 
     return True, 'Found pycharm'
 


### PR DESCRIPTION
- Fixes pycharm after utils.run detach broke it.
- Adds verbose prints when no .comeback found
- Adds .comeback path to the global paths file (weird we didn't notice this before).

PS, what is `paths.get_default_comeback_file_path`, why would I want a blank file in the middle of my home directory? ie:
![image](https://user-images.githubusercontent.com/1269911/54077673-70807200-42c4-11e9-882e-2b4265b91bc0.png)
